### PR TITLE
Update to support changes to String in Swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ script:
     - if [ $RUN_TESTS == "YES" ]; then xcodebuild clean test -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO; fi
     - if [ $RUN_TESTS != "YES" ]; then xcodebuild clean build -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO ; fi
 
-    - swift build
-    - swift test --parallel
+    - swift test
 
 after_success:
    - bash <(curl -s https://codecov.io/bash)

--- a/Sources/Differ/Diff.swift
+++ b/Sources/Differ/Diff.swift
@@ -101,43 +101,6 @@ extension Trace {
     }
 }
 
-public extension String {
-
-    /// Creates a diff between the calee and `to` string
-    ///
-    /// - Complexity: O((N+M)*D)
-    ///
-    /// - Parameters:
-    ///   - to: a string to compare the calee to.
-    /// - Returns: a Diff between the calee and `to` string
-    public func diff(to: String) -> Diff {
-        if self == to {
-            return Diff(elements: [])
-        }
-        return characters.diff(to.characters)
-    }
-
-    /// Creates an extended diff (includes insertions, deletions, and moves) between the calee and `other` string
-    ///
-    /// - Complexity: O((N+M)*D)
-    ///
-    /// - Parameters:
-    ///   - other: a string to compare the calee to.
-    /// - Returns: an ExtendedDiff between the calee and `other` string
-    public func extendedDiff(_ other: String) -> ExtendedDiff {
-        if self == other {
-            return ExtendedDiff(
-                source: Diff(elements: []),
-                sourceIndex: [],
-                reorderedIndex: [],
-                elements: [],
-                moveIndices: Set()
-            )
-        }
-        return characters.extendedDiff(other.characters)
-    }
-}
-
 extension Array {
     func value(at index: Index) -> Iterator.Element? {
         if index < 0 || index >= count {

--- a/Sources/Differ/ExtendedPatch+Apply.swift
+++ b/Sources/Differ/ExtendedPatch+Apply.swift
@@ -22,28 +22,3 @@ public extension RangeReplaceableCollection where Self.Iterator.Element: Equatab
         return mutableSelf
     }
 }
-
-public extension String {
-
-    public func apply(_ patch: [ExtendedPatch<String.CharacterView.Iterator.Element>]) -> String {
-        var mutableSelf = self
-
-        for change in patch {
-            switch change {
-            case let .insertion(i, element):
-                let target = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(i))
-                mutableSelf.insert(element, at: target)
-            case let .deletion(i):
-                let target = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(i))
-                mutableSelf.remove(at: target)
-            case let .move(from, to):
-                let fromIndex = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(from))
-                let toIndex = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(to))
-                let element = mutableSelf.remove(at: fromIndex)
-                mutableSelf.insert(element, at: toIndex)
-            }
-        }
-
-        return mutableSelf
-    }
-}

--- a/Sources/Differ/Patch+Apply.swift
+++ b/Sources/Differ/Patch+Apply.swift
@@ -17,23 +17,3 @@ public extension RangeReplaceableCollection where Self.Iterator.Element: Equatab
         return mutableSelf
     }
 }
-
-public extension String {
-
-    public func apply(_ patch: [Patch<String.CharacterView.Iterator.Element>]) -> String {
-        var mutableSelf = self
-
-        for change in patch {
-            switch change {
-            case let .insertion(i, element):
-                let target = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(i))
-                mutableSelf.insert(element, at: target)
-            case let .deletion(i):
-                let target = mutableSelf.index(mutableSelf.startIndex, offsetBy: IndexDistance(i))
-                mutableSelf.remove(at: target)
-            }
-        }
-
-        return mutableSelf
-    }
-}

--- a/Tests/DifferTests/DiffTests.swift
+++ b/Tests/DifferTests/DiffTests.swift
@@ -77,19 +77,19 @@ class DiffTests: XCTestCase {
     }
 
     func testSingleElementArray() {
-        let changes = "a".diff(to: "a")
+        let changes = "a".diff("a")
         XCTAssertEqual(changes.elements.count, 0)
     }
 
     func duplicateTraces(from: String, to: String) -> Bool {
-        let traces = from.characters.diffTraces(to: to.characters)
+        let traces = from.diffTraces(to: to)
         let tracesSet = Set(traces)
         return !(traces.count == tracesSet.count)
     }
 
     func tracesOutOfBounds(from: String, to: String) -> [Trace] {
-        let ac = from.characters
-        let bc = to.characters
+        let ac = from
+        let bc = to
         return ac.diffTraces(to: bc)
             .filter { $0.to.y > bc.count || $0.to.x > ac.count }
     }
@@ -98,7 +98,7 @@ class DiffTests: XCTestCase {
         from: String,
         to: String) -> String {
         return from
-            .diff(to: to)
+            .diff(to)
             .reduce("") { $0 + $1.debugDescription }
     }
 

--- a/Tests/DifferTests/ExtendedPatchSortTests.swift
+++ b/Tests/DifferTests/ExtendedPatchSortTests.swift
@@ -86,8 +86,8 @@ class ExtendedPatchSortTests: XCTestCase {
             let string1 = "eakjnrsignambmcbdcdhdkmhkolpdgfedcpgabtldjkaqkoobomuhpepirdcrdrgmrmaefesoiildmtnbronpmmbuuplnfnjgdhadkbmprensshiekknhskognpbknpbepmlakducnfktjeookncjpcnpklfedrebstisalskigsuojkookhbmkdafiaftrkrccupgjapqrigbanfbboapmicabeclhentlabourhtqmlboqctgorajirchesaorsgnigattkdrenquffcutffopbjrebegbfmkeikstqsut"
             let string2 = "mdjqtbchphncsjdkjtutagahmdtfcnjliipmqgrhgajsgotcdgidlghithdgrcmfuausmjnbtjghqblaiuldirulhllidbpcpglfbnfbkbddhdskdplsgjjsusractdplajrctgrcebhesbeneidsititlalsqkhliontgpesglkoorjqeniqaetatamneonhbhunqlfkbmfsjallnejhkcfaeapdnacqdtukcuiheiabqpudmgosssabisrrlmhcmpkgerhesqihdnfjmqgfnmulnfkmpqrsghutfsckurr"
             let patch = string1.extendedDiff(string2).patch(
-                from: string1.characters,
-                to: string2.characters,
+                from: string1,
+                to: string2,
                 sort: sort)
             let result = string1.apply(patch)
             XCTAssertEqual(result, string2)
@@ -103,13 +103,13 @@ func _extendedTest(
     sortingFunction: ExtendedSortingFunction? = nil) -> String {
     guard let sort = sortingFunction else {
         return extendedPatch(
-            from: from.characters,
-            to: to.characters)
+            from: from,
+            to: to)
             .reduce("") { $0 + $1.debugDescription }
     }
     return extendedPatch(
-        from: from.characters,
-        to: to.characters,
+        from: from,
+        to: to,
         sort: sort)
         .reduce("") { $0 + $1.debugDescription }
 }

--- a/Tests/DifferTests/PatchApplyTests.swift
+++ b/Tests/DifferTests/PatchApplyTests.swift
@@ -35,7 +35,7 @@ class PatchApplyTests: XCTestCase {
     }
 }
 
-func stringPatch(from textualRepresentation: String) -> [Patch<String.CharacterView.Iterator.Element>] {
+func stringPatch(from textualRepresentation: String) -> [Patch<Character>] {
     return textualRepresentation.components(separatedBy: ")").flatMap { string in
         if string == "" {
             return nil
@@ -48,7 +48,7 @@ func stringPatch(from textualRepresentation: String) -> [Patch<String.CharacterV
         } else if type == "I" {
             let startIndex = string.index(string.startIndex, offsetBy: 2)
             let indexAndElement = string[startIndex...].components(separatedBy: ",")
-            return .insertion(index: Int(indexAndElement[0])!, element: indexAndElement[1].characters.first!)
+            return .insertion(index: Int(indexAndElement[0])!, element: indexAndElement[1].first!)
         } else {
             return nil
         }

--- a/Tests/DifferTests/PatchSortTests.swift
+++ b/Tests/DifferTests/PatchSortTests.swift
@@ -119,7 +119,7 @@ class PatchTests: XCTestCase {
         for _ in 0 ..< 200 {
             let randomString = randomAlphaNumericString(length: 30)
             let permutation = randomAlphaNumericString(length: 30)
-            let patch = randomString.diff(to: permutation).patch(from: randomString.characters, to: permutation.characters, sort: sort)
+            let patch = randomString.diff(permutation).patch(from: randomString, to: permutation, sort: sort)
             let result = randomString.apply(patch)
             XCTAssertEqual(result, permutation)
         }
@@ -129,7 +129,7 @@ class PatchTests: XCTestCase {
 func randomAlphaNumericString(length: Int) -> String {
 
     let allowedChars = "abcdefghijklmnopqrstu"
-    let allowedCharsCount = UInt32(allowedChars.characters.count)
+    let allowedCharsCount = UInt32(allowedChars.count)
     var randomString = ""
 
     for _ in 0 ..< length {
@@ -150,13 +150,13 @@ func _test(
     sortingFunction: SortingFunction? = nil) -> String {
     if let sort = sortingFunction {
         return patch(
-            from: from.characters,
-            to: to.characters,
+            from: from,
+            to: to,
             sort: sort)
             .reduce("") { $0 + $1.debugDescription }
     }
     return patch(
-        from: from.characters,
-        to: to.characters)
+        from: from,
+        to: to)
         .reduce("") { $0 + $1.debugDescription }
 }


### PR DESCRIPTION
Swift 4.0 made the `String` struct a lot simpler than it is in Swift 3.0 (https://github.com/apple/swift/commit/7c705c3a7562d0a203335d5de2999575cf902a15). 

Xcode 9.0 did not warn about the deprecations fixed in this PR, however Xcode 9.1b1 does. 