### PR TITLE
Remove UIKit dependency at Linux

### DIFF
--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -1,4 +1,4 @@
-#if !os(macOS) && !os(watchOS)
+#if !os(macOS) && !os(watchOS) && !os(Linux)
 
     import UIKit
 


### PR DESCRIPTION
I use Differ on Linux, but it's uncompilable on Linux due to UIKit import. Simple check can fix it. 