### PR TITLE
Fix crash moving rows & sections

### DIFF
--- a/Examples/TableViewExample/TableViewExample/NestedTableViewController.swift
+++ b/Examples/TableViewExample/TableViewExample/NestedTableViewController.swift
@@ -43,6 +43,7 @@ class NestedTableViewController: UITableViewController {
                 elements: [
                     "👋🏻",
                     "🎁",
+                    "😊",
                 ],
                 key: "Second"
             ),
@@ -52,13 +53,13 @@ class NestedTableViewController: UITableViewController {
                 elements: [
                     "🎁",
                     "👋🏻",
+                    "🐩",
                 ],
                 key: "Second"
             ),
             StringArray(
                 elements: [
                     "🌞",
-                    "🐩",
                 ],
                 key: "First"
             ),

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -143,7 +143,10 @@
             beginUpdates()
             deleteRows(at: update.deletions, with: deletionAnimation)
             insertRows(at: update.insertions, with: insertionAnimation)
-            update.moves.forEach { moveRow(at: $0.from, to: $0.to) }
+            update.moves.forEach {
+                deleteRows(at: [$0.from], with: deletionAnimation)
+                insertRows(at: [$0.to], with: insertionAnimation)
+            }
             endUpdates()
         }
 
@@ -315,10 +318,16 @@
             beginUpdates()
             deleteRows(at: update.itemDeletions, with: rowDeletionAnimation)
             insertRows(at: update.itemInsertions, with: rowInsertionAnimation)
-            update.itemMoves.forEach { moveRow(at: $0.from, to: $0.to) }
+            update.itemMoves.forEach {
+                deleteRows(at: [$0.from], with: rowDeletionAnimation)
+                insertRows(at: [$0.to], with: rowInsertionAnimation)
+            }
             deleteSections(update.sectionDeletions, with: sectionDeletionAnimation)
             insertSections(update.sectionInsertions, with: sectionInsertionAnimation)
-            update.sectionMoves.forEach { moveSection($0.from, toSection: $0.to) }
+            update.sectionMoves.forEach {
+                deleteSections([$0.from], with: sectionDeletionAnimation)
+                insertSections([$0.to], with: sectionInsertionAnimation)
+            }
             endUpdates()
         }
     }


### PR DESCRIPTION
I noticed that sometimes UITableView asserts failure when applying diff with moveRows & moveSections.
It's reproducible in the TableViewExample project with some modification to the example data.

So far separating moves into deletions & insertions can resolve this issue, though I have not inspected the diff logic.
This PR includes a patch for UITableView.

```
2018-01-23 12:35:51.464473+0900 TableViewExample[16749:1512966] *** Assertion failure in -[_UITableViewUpdateSupport _setupAnimationsForNewlyInsertedCells], /BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit/UIKit-3698.33.7/UITableViewSupport.m:1295
2018-01-23 12:35:51.465157+0900 TableViewExample[16749:1512966] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Attempt to create two animations for cell'
```