### PR TITLE
Visibility of BatchUpdate.MoveStep fields

### DIFF
--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -4,8 +4,8 @@
 
     public struct BatchUpdate {
         public struct MoveStep: Equatable {
-            let from: IndexPath
-            let to: IndexPath
+            public let from: IndexPath
+            public let to: IndexPath
         }
 
         public let deletions: [IndexPath]


### PR DESCRIPTION
Would it be possible to make the BatchUpdate.MoveStep struct's fields public so one could access them outside the module?
