### PR TITLE
Add support for updating NSTableView rows

### DIFF
--- a/Differ.xcodeproj/project.pbxproj
+++ b/Differ.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		C9D4BC961E1124CE00C79537 /* NestedExtendedDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4BC951E1124CE00C79537 /* NestedExtendedDiff.swift */; };
 		C9EE87841CCFFB68006BD90E /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EE87821CCFFB68006BD90E /* Diff.swift */; };
 		C9EE87861CCFFB68006BD90E /* Patch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EE87831CCFFB68006BD90E /* Patch.swift */; };
+		CA14534D2075C648004A343A /* BatchUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA14534C2075C648004A343A /* BatchUpdate.swift */; };
+		CA14534F2075C73D004A343A /* Diff+AppKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA14534E2075C73D004A343A /* Diff+AppKit.swift */; };
 		E2F1C8561E3A14DF00FBE786 /* BatchUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F1C8551E3A14DF00FBE786 /* BatchUpdateTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -67,6 +69,8 @@
 		C9EE87161CCFCA83006BD90E /* Differ.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Differ.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9EE87821CCFFB68006BD90E /* Diff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Diff.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C9EE87831CCFFB68006BD90E /* Patch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Patch.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		CA14534C2075C648004A343A /* BatchUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchUpdate.swift; sourceTree = "<group>"; };
+		CA14534E2075C73D004A343A /* Diff+AppKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diff+AppKit.swift"; sourceTree = "<group>"; };
 		E2F1C8551E3A14DF00FBE786 /* BatchUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchUpdateTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -105,6 +109,8 @@
 			children = (
 				C9EE87821CCFFB68006BD90E /* Diff.swift */,
 				C9278ADD1DE32B88009CE846 /* Diff+UIKit.swift */,
+				CA14534E2075C73D004A343A /* Diff+AppKit.swift */,
+				CA14534C2075C648004A343A /* BatchUpdate.swift */,
 				C9B03FBF1DE1CA7500BC6F2A /* ExtendedDiff.swift */,
 				C99118AD1DDDAFEA00067A60 /* ExtendedPatch.swift */,
 				C96F41931DE0EEC500B8E135 /* ExtendedPatch+Apply.swift */,
@@ -277,6 +283,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C9B03FC01DE1CA7500BC6F2A /* ExtendedDiff.swift in Sources */,
+				CA14534F2075C73D004A343A /* Diff+AppKit.swift in Sources */,
 				C99118951DDB1BA800067A60 /* LinkedList.swift in Sources */,
 				C99118B81DE062BE00067A60 /* GenericPatch.swift in Sources */,
 				C9EE87861CCFFB68006BD90E /* Patch.swift in Sources */,
@@ -286,6 +293,7 @@
 				C991189B1DDB4EAB00067A60 /* Patch+Apply.swift in Sources */,
 				C96F41941DE0EEC500B8E135 /* ExtendedPatch+Apply.swift in Sources */,
 				C9EE87841CCFFB68006BD90E /* Diff.swift in Sources */,
+				CA14534D2075C648004A343A /* BatchUpdate.swift in Sources */,
 				C99118B01DDDB02D00067A60 /* ExtendedPatch.swift in Sources */,
 				C90CD7171DFB368200BE9114 /* NestedDiff.swift in Sources */,
 			);

--- a/Sources/Differ/BatchUpdate.swift
+++ b/Sources/Differ/BatchUpdate.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct BatchUpdate {
+    public struct MoveStep: Equatable {
+        public let from: IndexPath
+        public let to: IndexPath
+    }
+
+    public let deletions: [IndexPath]
+    public let insertions: [IndexPath]
+    public let moves: [MoveStep]
+}

--- a/Sources/Differ/Diff+AppKit.swift
+++ b/Sources/Differ/Diff+AppKit.swift
@@ -1,0 +1,100 @@
+#if !os(iOS) && !os(watchOS) && !os(Linux)
+
+    import AppKit
+
+    extension BatchUpdate {
+        public init(
+            diff: ExtendedDiff,
+            indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+        ) {
+            deletions = diff.compactMap { element -> IndexPath? in
+                switch element {
+                case let .delete(at):
+                    return indexPathTransform(IndexPath(item: at, section: 0))
+                default: return nil
+                }
+            }
+            insertions = diff.compactMap { element -> IndexPath? in
+                switch element {
+                case let .insert(at):
+                    return indexPathTransform(IndexPath(item: at, section: 0))
+                default: return nil
+                }
+            }
+            moves = diff.compactMap { element -> MoveStep? in
+                switch element {
+                case let .move(from, to):
+                    return MoveStep(from: indexPathTransform(IndexPath(item: from, section: 0)), to: indexPathTransform(IndexPath(item: to, section: 0)))
+                default: return nil
+                }
+            }
+        }
+    }
+
+    extension NSTableView {
+
+        /// Animates rows which changed between oldData and newData.
+        ///
+        /// - Parameters:
+        ///   - oldData:            Data which reflects the previous state of `NSTableView`
+        ///   - newData:            Data which reflects the current state of `NSTableView`
+        ///   - deletionAnimation:  Animation type for deletions
+        ///   - insertionAnimation: Animation type for insertions
+        ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired `IndexPath`
+        public func animateRowChanges<T: Collection>(
+            oldData: T,
+            newData: T,
+            deletionAnimation: NSTableView.AnimationOptions = [],
+            insertionAnimation: NSTableView.AnimationOptions = [],
+            indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+        ) where T.Iterator.Element: Equatable {
+            apply(
+                oldData.extendedDiff(newData),
+                deletionAnimation: deletionAnimation,
+                insertionAnimation: insertionAnimation,
+                indexPathTransform: indexPathTransform
+            )
+        }
+
+        /// Animates rows which changed between oldData and newData.
+        ///
+        /// - Parameters:
+        ///   - oldData:            Data which reflects the previous state of `NSTableView`
+        ///   - newData:            Data which reflects the current state of `NSTableView`
+        ///   - isEqual:            A function comparing two elements of `T`
+        ///   - deletionAnimation:  Animation type for deletions
+        ///   - insertionAnimation: Animation type for insertions
+        ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired `IndexPath`
+        public func animateRowChanges<T: Collection>(
+            oldData: T,
+            newData: T,
+            isEqual: EqualityChecker<T>,
+            deletionAnimation: NSTableView.AnimationOptions = [],
+            insertionAnimation: NSTableView.AnimationOptions = [],
+            indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+        ) {
+            apply(
+                oldData.extendedDiff(newData, isEqual: isEqual),
+                deletionAnimation: deletionAnimation,
+                insertionAnimation: insertionAnimation,
+                indexPathTransform: indexPathTransform
+            )
+        }
+
+        public func apply(
+            _ diff: ExtendedDiff,
+            deletionAnimation: NSTableView.AnimationOptions = [],
+            insertionAnimation: NSTableView.AnimationOptions = [],
+            indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+        ) {
+            let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
+
+            beginUpdates()
+            removeRows(at: IndexSet(update.deletions.map { $0.item }), withAnimation: deletionAnimation)
+            insertRows(at: IndexSet(update.insertions.map { $0.item }), withAnimation: insertionAnimation)
+            update.moves.forEach { moveRow(at: $0.from.item, to: $0.to.item) }
+            endUpdates()
+        }
+    }
+
+#endif

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -2,16 +2,7 @@
 
     import UIKit
 
-    public struct BatchUpdate {
-        public struct MoveStep: Equatable {
-            public let from: IndexPath
-            public let to: IndexPath
-        }
-
-        public let deletions: [IndexPath]
-        public let insertions: [IndexPath]
-        public let moves: [MoveStep]
-
+    extension BatchUpdate {
         public init(
             diff: ExtendedDiff,
             indexPathTransform: (IndexPath) -> IndexPath = { $0 }


### PR DESCRIPTION
This implements update and apply methods for NSTableView. It also moves BatchUpdate to a new file and keeps the initializers separate for each platform because of the different IndexPath properties that UITableView (row) and NSTableView (item) use.

This branch doesn't implement support for NSCollectionView or NSOutlineView because I don't have an immediate need for them, and so I don't have something built to test them with. NestedBatchUpdate could probably be moved as-is to BatchUpdate.swift in order to support NSCollectionView updates.

Todo:

- [ ] Update README