### PR TITLE
Use animator() proxy for NSCollectionView animations

### DIFF
--- a/Sources/Differ/Diff+AppKit.swift
+++ b/Sources/Differ/Diff+AppKit.swift
@@ -138,7 +138,8 @@ public extension NSCollectionView {
         completion: ((Bool) -> Swift.Void)? = nil,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
         ) {
-        performBatchUpdates({
+        self.animator()
+        .performBatchUpdates({
             let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
             self.deleteItems(at: Set(update.deletions))
             self.insertItems(at: Set(update.insertions))
@@ -270,7 +271,8 @@ public extension NSCollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Void)? = nil
         ) {
-        performBatchUpdates({
+        self.animator()
+        .performBatchUpdates({
             let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
             self.insertSections(update.sectionInsertions)
             self.deleteSections(update.sectionDeletions)


### PR DESCRIPTION
Currently the NSCollectionView extensions don't animate. It's nowhere to be found on https://developer.apple.com/documentation/appkit/nscollectionview/1525876-performbatchupdates, but you have to use `.animator()` on the calls to get animations.

I've actually ran into this same thing before, and got some help on StackOverflow: https://stackoverflow.com/questions/36856027/nscollectionview-performbatchupdates-doesnt-animate-changes

Hopefully the syntax is okay, I wasn't sure exactly how to align things with the closures :).