### PR TITLE
Disable code coverage for Release

### DIFF
--- a/Differ.xcodeproj/project.pbxproj
+++ b/Differ.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 			baseConfigurationReference = 900E039F1DE7C3370033A799 /* Universal-Framework-Target.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
We've just recently tried to submit a build to the AppStore with Bitcode enabled, which has produced an error. Tracing the error log, it appears to have occurred while attempting to thin Differ:

```
...
"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.1.0/lib/darwin/libclang_rt.ios.a" "-o" "/private/var/folders/pv/dzy6d7px7918hyd7zcbps5sw0000gn/T/BondLMqej7/Bond.armv7.out" 
    -= Output =-
    Undefined symbols for architecture armv7:
      "__T06Differ12ExtendedDiffV5patchSayAA0B5PatchOy7ElementQzGGx4from_x2toSbAcGO_AMtcSg4sortts10CollectionRzs9EquatableAHRQlF", referenced from:
          __hidden#1270_ in 14.o
          __hidden#3542_ in 52.o
    ld: symbol(s) not found for architecture armv7
    Exited with 1
    
    
    error: Failed to compile bundle: /var/folders/pv/dzy6d7px7918hyd7zcbps5sw0000gn/T/BondLMqej7/Bond.armv7.xar
    

Stderr:
>
    /Applications/Xcode.app/Contents/Developer/usr/bin/ipatool:227:in `run'
    /Applications/Xcode.app/Contents/Developer/usr/bin/ipatool:2255:in `block in CompileOrStripBitcodeInBundle'
```

From a bit of searching online, it looks like this can happen when code coverage is enabled for the Release scheme. Disabling it seems to have resolved the issue.

We're using Differ indirectly as a dependency of Bond through Carthage.