### PR TITLE
Fix a crash with unit tests under Swift 4.2

### DIFF
--- a/Sources/Differ/Diff.swift
+++ b/Sources/Differ/Diff.swift
@@ -63,28 +63,16 @@ extension Diff.Element {
     }
 }
 
-public struct Point {
+public struct Point: Hashable {
     public let x: Int
     public let y: Int
 }
 
-extension Point: Equatable {}
-
-public func ==(l: Point, r: Point) -> Bool {
-    return (l.x == r.x) && (l.y == r.y)
-}
-
 /// A data structure representing single trace produced by the diff algorithm. See the [paper](http://www.xmailserver.org/diff2.pdf) for more information on traces.
-public struct Trace {
+public struct Trace: Hashable {
     public let from: Point
     public let to: Point
     public let D: Int
-}
-
-extension Trace: Equatable {
-    public static func ==(l: Trace, r: Trace) -> Bool {
-        return (l.from == r.from) && (l.to == r.to)
-    }
 }
 
 enum TraceType {

--- a/Tests/DifferTests/DiffTests.swift
+++ b/Tests/DifferTests/DiffTests.swift
@@ -1,12 +1,6 @@
 import XCTest
 @testable import Differ
 
-extension Trace: Hashable {
-    public var hashValue: Int {
-        return (((51 + from.x.hashValue) * 51 + from.y.hashValue) * 51 + to.x.hashValue) * 51 + to.y.hashValue
-    }
-}
-
 class DiffTests: XCTestCase {
 
     let expectations = [


### PR DESCRIPTION
Hi 👋

Fun little project you have here. 😄 

I cloned the repo an running unit tests under Xcode 10 beta 5 I got a crash because of the custom Hashable conformance for Trace.  I thought I would use the autogenerated stuff.  Seemed to work well.  No more crashes.

The Hashable protocol has new conformance requirements. Under Swift 4.2
I am seeing crash in the unit test for tracing.  

(Since I see the use of "compactMap" I am assuming support of Swift 4.1 and up.  Automatic
Hashable conformance works for 4.1 and up.)

IMPORTANT NOTE:  The previous custom version of Trace equality leaves out the field D.  I am not sure this was intentional or not but adding it in (using the autogenerated version) doesn't seem to cause any test failures.

Anyway, hope this helps. If you would like to fix a different way that is fine.  Only a suggestion.  Thanks for maintaining this useful project. 😀