### PR TITLE
Replace Iterator.Element with simply Element

### DIFF
--- a/Sources/Differ/Diff+AppKit.swift
+++ b/Sources/Differ/Diff+AppKit.swift
@@ -46,7 +46,7 @@ extension NSTableView {
         deletionAnimation: NSTableView.AnimationOptions = [],
         insertionAnimation: NSTableView.AnimationOptions = [],
         indexPathTransform: (IndexPath) -> IndexPath = { $0 }
-    ) where T.Iterator.Element: Equatable {
+    ) where T.Element: Equatable {
         apply(
             oldData.extendedDiff(newData),
             deletionAnimation: deletionAnimation,
@@ -110,7 +110,7 @@ public extension NSCollectionView {
         newData: T,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         completion: ((Bool) -> Void)? = nil
-        ) where T.Iterator.Element: Equatable {
+        ) where T.Element: Equatable {
         let diff = oldData.extendedDiff(newData)
         apply(diff, completion: completion, indexPathTransform: indexPathTransform)
     }
@@ -163,9 +163,9 @@ public extension NSCollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable,
+        T.Element.Element: Equatable {
             self.apply(
                 oldData.nestedExtendedDiff(to: newData),
                 indexPathTransform: indexPathTransform,
@@ -179,7 +179,7 @@ public extension NSCollectionView {
     /// - Parameters:
     ///   - oldData:            Data which reflects the previous state of `UICollectionView`
     ///   - newData:            Data which reflects the current state of `UICollectionView`
-    ///   - isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     ///   - completion:         Closure to be executed when the animation completes
@@ -191,8 +191,8 @@ public extension NSCollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable {
             self.apply(
                 oldData.nestedExtendedDiff(
                     to: newData,
@@ -221,8 +221,8 @@ public extension NSCollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element.Element: Equatable {
             self.apply(
                 oldData.nestedExtendedDiff(
                     to: newData,
@@ -240,7 +240,7 @@ public extension NSCollectionView {
     ///   - oldData:            Data which reflects the previous state of `UICollectionView`
     ///   - newData:            Data which reflects the current state of `UICollectionView`
     ///   - isEqualSection:     A function comparing two sections (elements of `T`)
-    ///   - isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     ///   - completion:         Closure to be executed when the animation completes
@@ -253,7 +253,7 @@ public extension NSCollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
-        where T.Iterator.Element: Collection {
+        where T.Element: Collection {
             self.apply(
                 oldData.nestedExtendedDiff(
                     to: newData,

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -51,7 +51,7 @@ public extension UITableView {
         deletionAnimation: DiffRowAnimation = .automatic,
         insertionAnimation: DiffRowAnimation = .automatic,
         indexPathTransform: (IndexPath) -> IndexPath = { $0 }
-    ) where T.Iterator.Element: Equatable {
+    ) where T.Element: Equatable {
         self.apply(
             oldData.extendedDiff(newData),
             deletionAnimation: deletionAnimation,
@@ -121,9 +121,9 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath = { $0 },
         sectionTransform: (Int) -> Int = { $0 }
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable,
+        T.Element.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(to: newData),
             rowDeletionAnimation: rowDeletionAnimation,
@@ -140,7 +140,7 @@ public extension UITableView {
     /// - Parameters:
     ///   - oldData:                   Data which reflects the previous state of `UITableView`
     ///   - newData:                   Data which reflects the current state of `UITableView`
-    ///   - isEqualElement:            A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:            A function comparing two items (elements of `T.Element`)
     ///   - rowDeletionAnimation:      Animation type for row deletions
     ///   - rowInsertionAnimation:     Animation type for row insertions
     ///   - sectionDeletionAnimation:  Animation type for section deletions
@@ -158,8 +158,8 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath = { $0 },
         sectionTransform: (Int) -> Int = { $0 }
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,
@@ -197,8 +197,8 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath = { $0 },
         sectionTransform: (Int) -> Int = { $0 }
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,
@@ -219,7 +219,7 @@ public extension UITableView {
     ///   - oldData:                   Data which reflects the previous state of `UITableView`
     ///   - newData:                   Data which reflects the current state of `UITableView`
     ///   - isEqualSection:            A function comparing two sections (elements of `T`)
-    ///   - isEqualElement:            A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:            A function comparing two items (elements of `T.Element`)
     ///   - rowDeletionAnimation:      Animation type for row deletions
     ///   - rowInsertionAnimation:     Animation type for row insertions
     ///   - sectionDeletionAnimation:  Animation type for section deletions
@@ -238,7 +238,7 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath = { $0 },
         sectionTransform: (Int) -> Int = { $0 }
     )
-        where T.Iterator.Element: Collection {
+        where T.Element: Collection {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,
@@ -288,7 +288,7 @@ public extension UICollectionView {
         newData: T,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         completion: ((Bool) -> Void)? = nil
-    ) where T.Iterator.Element: Equatable {
+    ) where T.Element: Equatable {
         let diff = oldData.extendedDiff(newData)
         apply(diff, completion: completion, indexPathTransform: indexPathTransform)
     }
@@ -340,9 +340,9 @@ public extension UICollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable,
+        T.Element.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(to: newData),
             indexPathTransform: indexPathTransform,
@@ -356,7 +356,7 @@ public extension UICollectionView {
     /// - Parameters:
     ///   - oldData:            Data which reflects the previous state of `UICollectionView`
     ///   - newData:            Data which reflects the current state of `UICollectionView`
-    ///   - isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     ///   - completion:         Closure to be executed when the animation completes
@@ -368,8 +368,8 @@ public extension UICollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,
@@ -398,8 +398,8 @@ public extension UICollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
     )
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,
@@ -417,7 +417,7 @@ public extension UICollectionView {
     ///   - oldData:            Data which reflects the previous state of `UICollectionView`
     ///   - newData:            Data which reflects the current state of `UICollectionView`
     ///   - isEqualSection:     A function comparing two sections (elements of `T`)
-    ///   - isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
+    ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     ///   - completion:         Closure to be executed when the animation completes
@@ -430,7 +430,7 @@ public extension UICollectionView {
         sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
     )
-        where T.Iterator.Element: Collection {
+        where T.Element: Collection {
         self.apply(
             oldData.nestedExtendedDiff(
                 to: newData,

--- a/Sources/Differ/Diff.swift
+++ b/Sources/Differ/Diff.swift
@@ -98,7 +98,7 @@ extension Trace {
 }
 
 extension Array {
-    func value(at index: Index) -> Iterator.Element? {
+    func value(at index: Index) -> Element? {
         if index < 0 || index >= count {
             return nil
         }
@@ -113,7 +113,7 @@ struct TraceStep {
     let nextX: Int?
 }
 
-public typealias EqualityChecker<T: Collection> = (T.Iterator.Element, T.Iterator.Element) -> Bool
+public typealias EqualityChecker<T: Collection> = (T.Element, T.Element) -> Bool
 
 public extension Collection {
 
@@ -190,7 +190,7 @@ public extension Collection {
 
     fileprivate func myersDiffTraces(
         to: Self,
-        isEqual: (Iterator.Element, Iterator.Element) -> Bool
+        isEqual: (Element, Element) -> Bool
         ) -> [Trace] {
 
         // fromCount is N, N is the number of from array
@@ -309,7 +309,7 @@ public extension Collection {
     }
 }
 
-public extension Collection where Iterator.Element: Equatable {
+public extension Collection where Element: Equatable {
 
     /// - SeeAlso: `diff(_:isEqual:)`
     public func diff(

--- a/Sources/Differ/ExtendedDiff.swift
+++ b/Sources/Differ/ExtendedDiff.swift
@@ -168,7 +168,7 @@ public extension Collection {
     }
 }
 
-public extension Collection where Iterator.Element: Equatable {
+public extension Collection where Element: Equatable {
 
     /// - SeeAlso: `extendedDiff(_:isEqual:)`
     public func extendedDiff(_ other: Self) -> ExtendedDiff {
@@ -177,7 +177,7 @@ public extension Collection where Iterator.Element: Equatable {
 }
 
 extension Collection {
-    func itemOnStartIndex(advancedBy n: Int) -> Iterator.Element {
+    func itemOnStartIndex(advancedBy n: Int) -> Element {
         return self[self.index(startIndex, offsetBy: n)]
     }
 }

--- a/Sources/Differ/ExtendedPatch+Apply.swift
+++ b/Sources/Differ/ExtendedPatch+Apply.swift
@@ -1,6 +1,6 @@
 public extension RangeReplaceableCollection {
 
-    public func apply(_ patch: [ExtendedPatch<Iterator.Element>]) -> Self {
+    public func apply(_ patch: [ExtendedPatch<Element>]) -> Self {
         var mutableSelf = self
 
         for change in patch {

--- a/Sources/Differ/ExtendedPatch.swift
+++ b/Sources/Differ/ExtendedPatch.swift
@@ -46,7 +46,7 @@ public func extendedPatch<T: Collection>(
     from: T,
     to: T,
     sort: ExtendedDiff.OrderedBefore? = nil
-) -> [ExtendedPatch<T.Iterator.Element>] where T.Iterator.Element: Equatable {
+) -> [ExtendedPatch<T.Element>] where T.Element: Equatable {
     return from.extendedDiff(to).patch(from: from, to: to, sort: sort)
 }
 
@@ -66,16 +66,16 @@ extension ExtendedDiff {
         from: T,
         to: T,
         sort: OrderedBefore? = nil
-    ) -> [ExtendedPatch<T.Iterator.Element>] {
+    ) -> [ExtendedPatch<T.Element>] {
 
-        let result: [SortedPatchElement<T.Iterator.Element>]
+        let result: [SortedPatchElement<T.Element>]
         if let sort = sort {
             result = shiftedPatchElements(from: generateSortedPatchElements(from: from, to: to, sort: sort))
         } else {
             result = shiftedPatchElements(from: generateSortedPatchElements(from: from, to: to))
         }
 
-        return result.indices.compactMap { i -> ExtendedPatch<T.Iterator.Element>? in
+        return result.indices.compactMap { i -> ExtendedPatch<T.Element>? in
             let patchElement = result[i]
             if moveIndices.contains(patchElement.sourceIndex) {
                 let to = result[i + 1].value
@@ -109,7 +109,7 @@ extension ExtendedDiff {
         from: T,
         to: T,
         sort: @escaping OrderedBefore
-    ) -> [SortedPatchElement<T.Iterator.Element>] {
+    ) -> [SortedPatchElement<T.Element>] {
         let unboxed = boxDiffAndPatchElements(
             from: from,
             to: to
@@ -117,7 +117,7 @@ extension ExtendedDiff {
             return sort(from.diffElement, to.diffElement)
         }.flatMap(unbox)
 
-        return unboxed.indices.map { index -> SortedPatchElement<T.Iterator.Element> in
+        return unboxed.indices.map { index -> SortedPatchElement<T.Element> in
             let old = unboxed[index]
             return SortedPatchElement(
                 value: old.value,
@@ -128,7 +128,7 @@ extension ExtendedDiff {
         }
     }
 
-    func generateSortedPatchElements<T: Collection>(from: T, to: T) -> [SortedPatchElement<T.Iterator.Element>] {
+    func generateSortedPatchElements<T: Collection>(from: T, to: T) -> [SortedPatchElement<T.Element>] {
         let patch = source.patch(from: from, to: to)
         return patch.indices.map {
             SortedPatchElement(
@@ -142,7 +142,7 @@ extension ExtendedDiff {
     func boxDiffAndPatchElements<T: Collection>(
         from: T,
         to: T
-    ) -> [BoxedDiffAndPatchElement<T.Iterator.Element>] {
+    ) -> [BoxedDiffAndPatchElement<T.Element>] {
         let sourcePatch = generateSortedPatchElements(from: from, to: to)
         var indexDiff = 0
         return elements.indices.map { i in

--- a/Sources/Differ/NestedDiff.swift
+++ b/Sources/Differ/NestedDiff.swift
@@ -31,7 +31,7 @@ public struct NestedDiff: DiffProtocol {
 }
 
 public extension Collection
-    where Iterator.Element: Collection {
+    where Element: Collection {
 
     /// Creates a diff between the callee and `other` collection. It diffs elements two levels deep (therefore "nested")
     ///
@@ -94,8 +94,7 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element.Iterator.Element: Equatable {
+    where Element: Collection, Element.Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedDiff(
@@ -111,8 +110,7 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element: Equatable {
+    where Element: Collection, Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedDiff(
@@ -128,9 +126,8 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element: Equatable,
-    Iterator.Element.Iterator.Element: Equatable {
+    where Element: Collection, Element: Equatable,
+    Element.Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedDiff(to: Self) -> NestedDiff {

--- a/Sources/Differ/NestedExtendedDiff.swift
+++ b/Sources/Differ/NestedExtendedDiff.swift
@@ -32,10 +32,10 @@ public struct NestedExtendedDiff: DiffProtocol {
     }
 }
 
-public typealias NestedElementEqualityChecker<T: Collection> = (T.Iterator.Element.Iterator.Element, T.Iterator.Element.Iterator.Element) -> Bool where T.Iterator.Element: Collection
+public typealias NestedElementEqualityChecker<T: Collection> = (T.Element.Element, T.Element.Element) -> Bool where T.Element: Collection
 
 public extension Collection
-    where Iterator.Element: Collection {
+    where Element: Collection {
 
     /// Creates a diff between the callee and `other` collection. It diffs elements two levels deep (therefore "nested")
     ///
@@ -129,8 +129,8 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element.Iterator.Element: Equatable {
+    where Element: Collection,
+    Element.Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedExtendedDiff(
@@ -146,8 +146,7 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element: Equatable {
+    where Element: Collection, Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedExtendedDiff(
@@ -163,9 +162,8 @@ public extension Collection
 }
 
 public extension Collection
-    where Iterator.Element: Collection,
-    Iterator.Element: Equatable,
-    Iterator.Element.Iterator.Element: Equatable {
+    where Element: Collection, Element: Equatable,
+    Element.Element: Equatable {
 
     /// - SeeAlso: `nestedDiff(to:isEqualSection:isEqualElement:)`
     public func nestedExtendedDiff(to: Self) -> NestedExtendedDiff {

--- a/Sources/Differ/Patch+Apply.swift
+++ b/Sources/Differ/Patch+Apply.swift
@@ -1,6 +1,6 @@
 public extension RangeReplaceableCollection {
 
-    public func apply(_ patch: [Patch<Iterator.Element>]) -> Self {
+    public func apply(_ patch: [Patch<Element>]) -> Self {
         var mutableSelf = self
 
         for change in patch {

--- a/Sources/Differ/Patch+Sort.swift
+++ b/Sources/Differ/Patch+Sort.swift
@@ -11,7 +11,7 @@ public func patch<T: Collection>(
     from: T,
     to: T,
     sort: Diff.OrderedBefore
-) -> [Patch<T.Iterator.Element>] where T.Iterator.Element: Equatable {
+) -> [Patch<T.Element>] where T.Element: Equatable {
     return from.diff(to).patch(from: from, to: to, sort: sort)
 }
 
@@ -32,7 +32,7 @@ public extension Diff {
         from: T,
         to: T,
         sort: OrderedBefore
-    ) -> [Patch<T.Iterator.Element>] {
+    ) -> [Patch<T.Element>] {
         let shiftedPatch = patch(from: from, to: to)
         return shiftedPatchElements(from: sortedPatchElements(
             from: shiftedPatch,

--- a/Sources/Differ/Patch.swift
+++ b/Sources/Differ/Patch.swift
@@ -28,7 +28,7 @@ public extension Diff {
     public func patch<T: Collection>(
         from: T,
         to: T
-    ) -> [Patch<T.Iterator.Element>] {
+    ) -> [Patch<T.Element>] {
         var shift = 0
         return map { element in
             switch element {
@@ -54,7 +54,7 @@ public extension Diff {
 public func patch<T: Collection>(
     from: T,
     to: T
-) -> [Patch<T.Iterator.Element>] where T.Iterator.Element: Equatable {
+) -> [Patch<T.Element>] where T.Element: Equatable {
     return from.diff(to).patch(from: from, to: to)
 }
 

--- a/Tests/DifferTests/NestedDiffTests.swift
+++ b/Tests/DifferTests/NestedDiffTests.swift
@@ -195,7 +195,7 @@ class NestedDiffTests: XCTestCase {
         to: [T]) -> String
         where
         T: Equatable,
-        T.Iterator.Element: Equatable {
+        T.Element: Equatable {
         return from
             .nestedDiff(to: to)
             .reduce("") { $0 + $1.debugDescription }

--- a/Tests/DifferTests/NestedExtendedDiffTests.swift
+++ b/Tests/DifferTests/NestedExtendedDiffTests.swift
@@ -159,9 +159,9 @@ class NestedExtendedDiffTests: XCTestCase {
     }
 
     func _test<T: Collection>(from: T, to: T) -> String
-        where T.Iterator.Element: Collection,
-        T.Iterator.Element: Equatable,
-        T.Iterator.Element.Iterator.Element: Equatable {
+        where T.Element: Collection,
+        T.Element: Equatable,
+        T.Element.Element: Equatable {
         return from
             .nestedExtendedDiff(to: to)
             .reduce("") { $0 + $1.debugDescription }


### PR DESCRIPTION
Hi again,

Getting used to the code base.  You might find this change useful.  It is somewhat along the lines of the less code (verbose) is better mantra. 😄

From Swift 4, Sequence has the associatedtype Element constrained as Element == Iterator.Element. Thanks to (SE-0142).  So you can now just use Element everywhere you used to use Iterator.Element in Swift 3.

This is a non-source breaking change.