### PR TITLE
Remove unnecessary "from" parameter from Diff.patch(…)

### DIFF
--- a/Sources/Differ/ExtendedPatch.swift
+++ b/Sources/Differ/ExtendedPatch.swift
@@ -129,7 +129,7 @@ extension ExtendedDiff {
     }
 
     func generateSortedPatchElements<T: Collection>(from: T, to: T) -> [SortedPatchElement<T.Element>] {
-        let patch = source.patch(from: from, to: to)
+        let patch = source.patch(to: to)
         return patch.indices.map {
             SortedPatchElement(
                 value: patch[$0],

--- a/Sources/Differ/Patch+Sort.swift
+++ b/Sources/Differ/Patch+Sort.swift
@@ -33,7 +33,7 @@ public extension Diff {
         to: T,
         sort: OrderedBefore
     ) -> [Patch<T.Element>] {
-        let shiftedPatch = patch(from: from, to: to)
+        let shiftedPatch = patch(to: to)
         return shiftedPatchElements(from: sortedPatchElements(
             from: shiftedPatch,
             sortBy: sort

--- a/Sources/Differ/Patch.swift
+++ b/Sources/Differ/Patch.swift
@@ -22,13 +22,9 @@ public extension Diff {
     /// - Complexity: O(N)
     ///
     /// - Parameters:
-    ///   - from: The source collection (usually the source collecetion of the callee)
     ///   - to: The target collection (usually the target collecetion of the callee)
     /// - Returns: A sequence of steps to obtain `to` collection from the `from` one.
-    public func patch<T: Collection>(
-        from: T,
-        to: T
-    ) -> [Patch<T.Element>] {
+    public func patch<T: Collection>(to: T) -> [Patch<T.Element>] {
         var shift = 0
         return map { element in
             switch element {
@@ -55,7 +51,7 @@ public func patch<T: Collection>(
     from: T,
     to: T
 ) -> [Patch<T.Element>] where T.Element: Equatable {
-    return from.diff(to).patch(from: from, to: to)
+    return from.diff(to).patch(to: to)
 }
 
 extension Patch: CustomDebugStringConvertible {


### PR DESCRIPTION
The parameter was unused in the body of the method, thus is unnecessary.

Fixes #45