### PR TITLE
Make NestedBatchUpdate public

### DIFF
--- a/Sources/Differ/NestedBatchUpdate.swift
+++ b/Sources/Differ/NestedBatchUpdate.swift
@@ -4,15 +4,15 @@
 #if !os(watchOS)
 import Foundation
 
-struct NestedBatchUpdate {
-    let itemDeletions: [IndexPath]
-    let itemInsertions: [IndexPath]
-    let itemMoves: [(from: IndexPath, to: IndexPath)]
-    let sectionDeletions: IndexSet
-    let sectionInsertions: IndexSet
-    let sectionMoves: [(from: Int, to: Int)]
+public struct NestedBatchUpdate {
+    public let itemDeletions: [IndexPath]
+    public let itemInsertions: [IndexPath]
+    public let itemMoves: [(from: IndexPath, to: IndexPath)]
+    public let sectionDeletions: IndexSet
+    public let sectionInsertions: IndexSet
+    public let sectionMoves: [(from: Int, to: Int)]
 
-    init(
+    public init(
         diff: NestedExtendedDiff,
         indexPathTransform: (IndexPath) -> IndexPath = { $0 },
         sectionTransform: (Int) -> Int = { $0 }


### PR DESCRIPTION
Some clients wants to use `BatchUpdate` and `NestedBatchUpdate` in their apps. `BatchUpdate` is already a `public` struct, but `NestedBatchUpdate` isn't. This PR exposes `NestedBatchUpdate` struct to clients that wants to use it.
Also, when running tests on an Apple TV simulator there's a warning in Xcode that says `TARGETED_DEVICE_FAMILY value (1,2,4) does not contain any device family values compatible with the tvOS platform. Please add the value '3' to the TARGETED_DEVICE_FAMILY build setting to indicate that this target supports the 'tv' device family.`. I fixed it by adding `3` to `TARGETED_DEVICE_FAMILY`.