### PR TITLE
Refactored implementation of the fix from merge #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,22 +83,46 @@ However, if we decided to sort it so that deletions and higher indices are proce
 
 ### Table and Collection Views
 
-```swift
-// The following will automatically animate deletions, insertions, and moves:
 
+The following will automatically animate deletions, insertions, and moves:
+
+```swift
 tableView.animateRowChanges(oldData: old, newData: new)
 
-collectionView.animateItemChanges(oldData: old, newData: new)
+collectionView.animateItemChanges(oldData: old, newData: new, updateData: { self.dataSource = new })
+```
 
-// It can work with sections, too!
-
+It can work with sections, too!
+```swift
 tableView.animateRowAndSectionChanges(oldData: old, newData: new)
 
-collectionView.animateItemAndSectionChanges(oldData: old, newData: new)
+collectionView.animateItemAndSectionChanges(oldData: old, newData: new, updateData: { self.dataSource = new })
+```
 
+You can also calculate `diff` separately and use it later:
+```swift
+// Generate the difference first
+let diff = dataSource.diff(newDataSource)
+
+// This will apply changes to dataSource.
+let dataSourceUpdate = { self.dataSource = newDataSource }
+
+// ...
+
+tableView.apply(diff)
+
+collectionView.apply(diff, updateData: dataSourceUpdate)
 ```
 
 Please see the [included examples](/Examples/) for a working sample.
+
+#### Note about `updateData`
+
+Since version `2.0.0` there is now an `updateData` closure which notifies you when it's an appropriate time to update  `dataSource` of your `UICollectionView`. This addition refers to UICollectionView's [performbatchUpdates](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates):
+
+> If the collection view's layout is not up to date before you call this method, a reload may occur. To avoid problems, you should update your data model inside the updates block or ensure the layout is updated before you call `performBatchUpdates(_:completion:)`.
+
+Thus, it is **recommended** to update your `dataSource` inside `updateData` closure to avoid potential crashes during animations.
 
 ### Using Patch and Diff
 

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -253,16 +253,17 @@ public extension UICollectionView {
     ///   - oldData:            Data which reflects the previous state of `UICollectionView`
     ///   - newData:            Data which reflects the current state of `UICollectionView`
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Void)? = nil
     ) where T.Element: Equatable {
         let diff = oldData.extendedDiff(newData)
-        apply(diff, data: newData, updateData: updateData, completion: completion, indexPathTransform: indexPathTransform)
+        apply(diff, updateData: updateData, completion: completion, indexPathTransform: indexPathTransform)
     }
 
     /// Animates items which changed between oldData and newData.
@@ -272,28 +273,28 @@ public extension UICollectionView {
     ///   - newData:            Data which reflects the current state of `UICollectionView`
     ///   - isEqual:            A function comparing two elements of `T`
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
         isEqual: EqualityChecker<T>,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil
     ) {
         let diff = oldData.extendedDiff(newData, isEqual: isEqual)
-        apply(diff, data: newData, updateData: updateData, completion: completion, indexPathTransform: indexPathTransform)
+        apply(diff, updateData: updateData, completion: completion, indexPathTransform: indexPathTransform)
     }
 
-    func apply<T>(
+    func apply(
         _ diff: ExtendedDiff,
-        data: T,
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
     ) {
         performBatchUpdates({
-            updateData?(data)
+            updateData()
             let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
             self.deleteItems(at: update.deletions)
             self.insertItems(at: update.insertions)
@@ -308,13 +309,14 @@ public extension UICollectionView {
     ///   - newData:            Data which reflects the current state of `UICollectionView`
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         sectionTransform: @escaping (Int) -> Int = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil
     )
         where T.Element: Collection,
@@ -322,7 +324,6 @@ public extension UICollectionView {
         T.Element.Element: Equatable {
         self.apply(
             oldData.nestedExtendedDiff(to: newData),
-            data: newData,
             indexPathTransform: indexPathTransform,
             sectionTransform: sectionTransform,
             updateData: updateData,
@@ -338,6 +339,7 @@ public extension UICollectionView {
     ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
@@ -345,7 +347,7 @@ public extension UICollectionView {
         isEqualElement: NestedElementEqualityChecker<T>,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         sectionTransform: @escaping (Int) -> Int = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil
     )
         where T.Element: Collection,
@@ -355,7 +357,6 @@ public extension UICollectionView {
                 to: newData,
                 isEqualElement: isEqualElement
             ),
-            data: newData,
             indexPathTransform: indexPathTransform,
             sectionTransform: sectionTransform,
             updateData: updateData,
@@ -371,6 +372,7 @@ public extension UICollectionView {
     ///   - isEqualSection:     A function comparing two sections (elements of `T`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source.
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
@@ -378,7 +380,7 @@ public extension UICollectionView {
         isEqualSection: EqualityChecker<T>,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         sectionTransform: @escaping (Int) -> Int = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil
     )
         where T.Element: Collection,
@@ -388,7 +390,6 @@ public extension UICollectionView {
                 to: newData,
                 isEqualSection: isEqualSection
             ),
-            data: newData,
             indexPathTransform: indexPathTransform,
             sectionTransform: sectionTransform,
             updateData: updateData,
@@ -405,6 +406,7 @@ public extension UICollectionView {
     ///   - isEqualElement:     A function comparing two items (elements of `T.Element`)
     ///   - indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     ///   - sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
+    ///   - updateData:         Closure to be called immediately before performing updates, giving you a chance to correctly update data source
     ///   - completion:         Closure to be executed when the animation completes
     func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
@@ -413,7 +415,7 @@ public extension UICollectionView {
         isEqualElement: NestedElementEqualityChecker<T>,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         sectionTransform: @escaping (Int) -> Int = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Swift.Void)? = nil
     )
         where T.Element: Collection {
@@ -423,7 +425,6 @@ public extension UICollectionView {
                 isEqualSection: isEqualSection,
                 isEqualElement: isEqualElement
             ),
-            data: newData,
             indexPathTransform: indexPathTransform,
             sectionTransform: sectionTransform,
             updateData: updateData,
@@ -431,16 +432,15 @@ public extension UICollectionView {
         )
     }
 
-    func apply<T: Collection>(
+    func apply(
         _ diff: NestedExtendedDiff,
-        data: T,
         indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
         sectionTransform: @escaping (Int) -> Int = { $0 },
-        updateData: ((T) -> Void)? = nil,
+        updateData: () -> Void,
         completion: ((Bool) -> Void)? = nil
     ) {
         performBatchUpdates({
-            updateData?(data)
+            updateData()
             let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
             self.insertSections(update.sectionInsertions)
             self.deleteSections(update.sectionDeletions)


### PR DESCRIPTION
I've been looking into the change from #56 and found a couple of issues with it:

1) Making `apply` generic and passing `data` to it was excessive for a few reasons
1.1. it is not used in the method in any way besides simply passing it back in the appropriate time.
1.2. passing it back in `updateData` is redundant anyway since you pass `updateData` within the same call to `apply` which means you have access to your data source, thus can update it with new data source you used to get `diff` in the first place.
```swift
let previousDataSource = dataSource
let diff = newDataSource.diff(previousDataSource)
collectionView.apply(diff, updateData: { self.dataSource = newDataSource })
```

2) Marking `updateData` as optional with default value set to `nil` kinda makes all these changes meaningless: if one forgets to pass `updateData` closure it will effectively work as it did before.

In the PR I've addressed these issues.

P.S. Also based on [this](https://en.wikipedia.org/wiki/Software_versioning#Degree_of_compatibility) I'd suggest avoiding incompatible API changes outside of **major** releases. (Thus making this particular change be released as `2.0.0`)