### PR TITLE
Fix stack overflow when diffing large collections on background threads

### DIFF
--- a/Sources/Differ/GenericPatch.swift
+++ b/Sources/Differ/GenericPatch.swift
@@ -34,15 +34,13 @@ func edgeType<T>(from: DoublyLinkedList<SortedPatchElement<T>>, to: DoublyLinked
     }
 }
 
-func shiftPatchElement<T>(node: DoublyLinkedList<SortedPatchElement<T>>) {
-    var from = node.previous
-    while let nextFrom = from, nextFrom.value.sourceIndex < node.value.sourceIndex {
-        shiftPatchElement(from: nextFrom, to: node)
-        from = nextFrom.previous
-    }
-
-    if let next = node.next {
-        shiftPatchElement(node: next)
+func shiftPatchElement<T>(node list: DoublyLinkedList<SortedPatchElement<T>>) {
+    for node in list.makeNodeIterator() {
+        var from = node.previous
+        while let nextFrom = from, nextFrom.value.sourceIndex < node.value.sourceIndex {
+            shiftPatchElement(from: nextFrom, to: node)
+            from = nextFrom.previous
+        }
     }
 }
 
@@ -105,7 +103,7 @@ func shiftedPatchElements<T>(from sortedPatchElements: [SortedPatchElement<T>]) 
         shiftPatchElement(node: secondElement)
     }
 
-    guard let result = linkedList?.array().sorted(by: { (fst, second) -> Bool in
+    guard let result = linkedList?.sorted(by: { (fst, second) -> Bool in
         fst.sortedIndex < second.sortedIndex
     }) else {
         return []

--- a/Sources/Differ/LinkedList.swift
+++ b/Sources/Differ/LinkedList.swift
@@ -1,4 +1,4 @@
-class LinkedList<T> {
+class LinkedList<T>: Sequence {
     let next: LinkedList?
     let value: T
 
@@ -23,15 +23,22 @@ class LinkedList<T> {
         value = first
     }
 
-    func array() -> Array<T> {
-        if let next = next {
-            return [value] + next.array()
-        }
-        return [value]
+    /// Non-consuming iterator.
+    func makeIterator() -> AnyIterator<T> {
+        var node = self as Optional
+
+        return AnyIterator({
+            if let unwrapped = node {
+                node = unwrapped.next
+                return unwrapped.value
+            } else {
+                return nil
+            }
+        })
     }
 }
 
-class DoublyLinkedList<T> {
+class DoublyLinkedList<T>: Sequence {
     let next: DoublyLinkedList?
     private(set) weak var previous: DoublyLinkedList?
     var head: DoublyLinkedList {
@@ -72,13 +79,34 @@ class DoublyLinkedList<T> {
         guard let linkedList = linkedList else {
             return nil
         }
-        self.init(array: linkedList.array())
+        self.init(array: Array(linkedList))
     }
 
-    func array() -> Array<T> {
-        if let next = next {
-            return [value] + next.array()
-        }
-        return [value]
+    /// Non-consuming iterator.
+    func makeIterator() -> AnyIterator<T> {
+        var node = self as Optional
+
+        return AnyIterator({
+            if let unwrapped = node {
+                node = unwrapped.next
+                return unwrapped.value
+            } else {
+                return nil
+            }
+        })
+    }
+
+    /// Non-consuming iterator.
+    func makeNodeIterator() -> AnyIterator<DoublyLinkedList<T>> {
+        var node = self as Optional
+
+        return AnyIterator({
+            if let unwrapped = node {
+                node = unwrapped.next
+                return unwrapped
+            } else {
+                return nil
+            }
+        })
     }
 }

--- a/Tests/DifferTests/PatchSortTests.swift
+++ b/Tests/DifferTests/PatchSortTests.swift
@@ -124,6 +124,33 @@ class PatchTests: XCTestCase {
             XCTAssertEqual(result, permutation)
         }
     }
+
+    // See https://github.com/tonyarnold/Differ/issues/63
+    func testLargeCollectionOnBackgroundThread() {
+        let FIRST_STRING = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vel turpis nunc eget lorem dolor sed viverra ipsum. Pharetra pharetra massa massa ultricies mi quis hendrerit. Sit amet porttitor eget dolor morbi non arcu risus quis. Cursus risus at ultrices mi tempus imperdiet nulla malesuada. Odio ut enim blandit volutpat maecenas volutpat blandit aliquam. Eu ultrices vitae auctor eu augue ut. Urna condimentum mattis pellentesque id nibh. Vestibulum lorem sed risus ultricies tristique. Tempor orci eu lobortis elementum. Purus faucibus ornare suspendisse sed nisi lacus. Fames ac turpis egestas maecenas pharetra convallis posuere morbi leo.
+Neque volutpat ac tincidunt vitae semper quis lectus nulla. Eu turpis egestas pretium aenean pharetra magna ac placerat. Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Mauris a diam maecenas sed enim ut sem. Pellentesque massa placerat duis ultricies lacus. Nullam non nisi est sit amet facilisis magna etiam. Eget mauris pharetra et ultrices neque ornare aenean euismod elementum. Ipsum dolor sit amet consectetur adipiscing elit duis tristique. Tellus rutrum tellus pellentesque eu tincidunt tortor. Id volutpat lacus laoreet non curabitur gravida arcu. Tellus at urna condimentum mattis pellentesque id nibh tortor id. Viverra maecenas accumsan lacus vel facilisis volutpat est velit. Ut ornare lectus sit amet est placerat in egestas. Vestibulum sed arcu non odio euismod lacinia. Pellentesque habitant morbi tristique senectus et netus et malesuada fames. Felis donec et odio pellentesque diam volutpat commodo sed.
+Diam ut venenatis tellus in metus. Ultrices tincidunt arcu non sodales. Id velit ut tortor pretium viverra suspendisse potenti. Amet commodo nulla facilisi nullam vehicula. Blandit massa enim nec dui nunc mattis enim ut. Massa tempor nec feugiat nisl. Sed odio morbi quis commodo odio aenean. Dui ut ornare lectus sit amet est placerat in egestas. Varius vel pharetra vel turpis nunc eget lorem dolor sed. In cursus turpis massa tincidunt dui ut ornare lectus sit.
+"""
+        let SECOND_STRING = """
+Proin sagittis nisl rhoncus mattis rhoncus urna neque viverra. Auctor eu augue ut lectus arcu. Condimentum lacinia quis vel eros donec. Aliquam purus sit amet luctus venenatis lectus magna fringilla urna. Tellus mauris a diam maecenas sed enim ut sem. Pharetra et ultrices neque ornare aenean. Pulvinar pellentesque habitant morbi tristique senectus et netus et malesuada. Nunc faucibus a pellentesque sit amet porttitor eget. Neque convallis a cras semper auctor. Faucibus vitae aliquet nec ullamcorper. Lectus mauris ultrices eros in cursus turpis. Elit sed vulputate mi sit amet. Dolor morbi non arcu risus quis varius quam quisque. Et malesuada fames ac turpis. Libero id faucibus nisl tincidunt eget nullam non nisi est. Eget dolor morbi non arcu risus quis. Id porta nibh venenatis cras sed felis. Quis imperdiet massa tincidunt nunc pulvinar. Tincidunt dui ut ornare lectus sit amet est placerat. Ultrices tincidunt arcu non sodales neque sodales ut.
+Erat nam at lectus urna. Tellus at urna condimentum mattis. Aliquam vestibulum morbi blandit cursus risus at ultrices. Tristique senectus et netus et malesuada fames ac turpis. Arcu odio ut sem nulla pharetra diam sit amet nisl. Lorem sed risus ultricies tristique nulla aliquet. Ac turpis egestas maecenas pharetra convallis posuere morbi. Dolor sed viverra ipsum nunc. Nunc mattis enim ut tellus elementum sagittis vitae. Congue mauris rhoncus aenean vel elit scelerisque mauris. Dapibus ultrices in iaculis nunc sed augue lacus viverra vitae. Amet luctus venenatis lectus magna fringilla urna porttitor rhoncus. Suspendisse sed nisi lacus sed.
+Non quam lacus suspendisse faucibus. Urna porttitor rhoncus dolor purus non enim praesent. Ultrices sagittis orci a scelerisque purus semper. Ultricies lacus sed turpis tincidunt. Pharetra vel turpis nunc eget lorem dolor sed viverra. Tortor pretium viverra suspendisse potenti nullam ac tortor vitae purus. Sit amet massa vitae tortor. Laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean. Eu tincidunt tortor aliquam nulla facilisi cras fermentum. Cras ornare arcu dui vivamus arcu felis bibendum ut. Convallis tellus id interdum velit laoreet id. Ac turpis egestas sed tempus urna et. Facilisis sed odio morbi quis commodo odio aenean. Felis eget nunc lobortis mattis. Neque gravida in fermentum et sollicitudin ac orci. Id diam maecenas ultricies mi eget. Sit amet aliquam id diam maecenas. Blandit libero volutpat sed cras ornare arcu dui vivamus arcu. Mauris ultrices eros in cursus turpis massa tincidunt dui.
+"""
+        let source = Array(FIRST_STRING).map(String.init)
+        let target = Array(SECOND_STRING).map(String.init)
+        let predicate: (Diff.Element, Diff.Element) -> Bool = { _, _ in false }
+
+        let expectation = self.expectation(description: "Patch")
+
+        DispatchQueue.global().async(execute: {
+            let patch = Differ.patch(from: source, to: target, sort: predicate)
+            XCTAssertEqual(source.apply(patch), target)
+            expectation.fulfill()
+        })
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
 }
 
 func randomAlphaNumericString(length: Int) -> String {


### PR DESCRIPTION
Fixes https://github.com/tonyarnold/Differ/issues/63.
Fixes https://github.com/tonyarnold/Differ/issues/44.

As I mentioned over there, the issue is a stack overflow in large data sets due to recursive implementations of various methods operating on linked lists. I am unsure as to why this wasn't an issue on the main thread, but this fix should be an improvement nonetheless.

The recursive methods could easily be converted to be iterative or removed altogether by conforming the linked lists to `Sequence` and using `for in` loops to iterate over them.

I'm not sure if we should include the large, previously-failing test case as it takes quite a few seconds to run. It needs to be large enough to cause the stack overflow though.