### PR TITLE
Fix warnings presented in Xcode 11.4

### DIFF
--- a/Differ.xcodeproj/project.pbxproj
+++ b/Differ.xcodeproj/project.pbxproj
@@ -250,11 +250,11 @@
 			};
 			buildConfigurationList = C9EE87101CCFCA83006BD90E /* Build configuration list for PBXProject "Differ" */;
 			compatibilityVersion = "Xcode 10.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				Base,
+				en,
 			);
 			mainGroup = C9EE870C1CCFCA83006BD90E;
 			productRefGroup = C9EE87171CCFCA83006BD90E /* Products */;

--- a/Sources/Differ/NestedBatchUpdate.swift
+++ b/Sources/Differ/NestedBatchUpdate.swift
@@ -36,8 +36,8 @@ public struct NestedBatchUpdate {
                 sectionDeletions.insert(sectionTransform(at))
             case let .insertSection(at):
                 sectionInsertions.insert(sectionTransform(at))
-            case let .moveSection(move):
-                sectionMoves.append((sectionTransform(move.from), sectionTransform(move.to)))
+            case let .moveSection(moveFrom, moveTo):
+                sectionMoves.append((sectionTransform(moveFrom), sectionTransform(moveTo)))
             }
         }
 


### PR DESCRIPTION
If imported into a project built in Xcode 11.4 with swift warnings as errors enabled the project will fail to build. There is only one swift warning to fix and the other is cleaning up the project localization warning while at it.

I have verified the change with Xcode 11.3 too but no further back. Let me know if any other tests are required.

<img width="276" alt="Screen Shot 2020-03-28 at 8 19 59 pm" src="https://user-images.githubusercontent.com/117041/77819905-96c4ba00-7132-11ea-9d29-e7e27b52af7b.png">
