### PR TITLE
Fix NSTableView batch update 1234 -> 3412

### DIFF
--- a/Sources/Differ/BatchUpdate.swift
+++ b/Sources/Differ/BatchUpdate.swift
@@ -24,7 +24,7 @@ public struct BatchUpdate {
             case let .move(from, to):
                 moves.append(MoveStep(from: indexPathTransform([0, from]), to: indexPathTransform([0, to])))
             }
-            return (deletions, insertions, moves)
+            return (deletions, insertions, moves.reversed())
         })
     }
 }

--- a/Tests/DifferTests/BatchUpdateTests.swift
+++ b/Tests/DifferTests/BatchUpdateTests.swift
@@ -17,6 +17,7 @@ class BatchUpdateTests: XCTestCase {
     private let cellExpectations: [Expectation] = [
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [1, 2, 3, 4], insertions: [], deletions: [], moves: []),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [4, 2, 3, 1], insertions: [], deletions: [], moves: [BatchUpdate.MoveStep(from: IP(0, 0), to: IP(3, 0)), BatchUpdate.MoveStep(from: IP(3, 0), to: IP(0, 0))]),
+        Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [3, 4, 1, 2], insertions: [], deletions: [], moves: [BatchUpdate.MoveStep(from: IP(1, 0), to: IP(3, 0)), BatchUpdate.MoveStep(from: IP(0, 0), to: IP(2, 0))]),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [2, 3, 1], insertions: [], deletions: [IP(3, 0)], moves: [BatchUpdate.MoveStep(from: IP(0, 0), to: IP(2, 0))]),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [5, 2, 3, 4], insertions: [IP(0, 0)], deletions: [IP(0, 0)], moves: []),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [4, 1, 3, 5], insertions: [IP(3, 0)], deletions: [IP(1, 0)], moves: [BatchUpdate.MoveStep(from: IP(3, 0), to: IP(0, 0))]),

--- a/Tests/DifferTests/BatchUpdateTests.swift
+++ b/Tests/DifferTests/BatchUpdateTests.swift
@@ -16,7 +16,7 @@ class BatchUpdateTests: XCTestCase {
 
     private let cellExpectations: [Expectation] = [
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [1, 2, 3, 4], insertions: [], deletions: [], moves: []),
-        Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [4, 2, 3, 1], insertions: [], deletions: [], moves: [BatchUpdate.MoveStep(from: IP(0, 0), to: IP(3, 0)), BatchUpdate.MoveStep(from: IP(3, 0), to: IP(0, 0))]),
+        Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [4, 2, 3, 1], insertions: [], deletions: [], moves: [BatchUpdate.MoveStep(from: IP(3, 0), to: IP(0, 0)), BatchUpdate.MoveStep(from: IP(0, 0), to: IP(3, 0))]),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [3, 4, 1, 2], insertions: [], deletions: [], moves: [BatchUpdate.MoveStep(from: IP(1, 0), to: IP(3, 0)), BatchUpdate.MoveStep(from: IP(0, 0), to: IP(2, 0))]),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [2, 3, 1], insertions: [], deletions: [IP(3, 0)], moves: [BatchUpdate.MoveStep(from: IP(0, 0), to: IP(2, 0))]),
         Expectation(orderBefore: [1, 2, 3, 4], orderAfter: [5, 2, 3, 4], insertions: [IP(0, 0)], deletions: [IP(0, 0)], moves: []),


### PR DESCRIPTION
I had an issue where NSTableView wouldn't execute the moves correctly for the scenario
`0123` → `2301`

I realized that the moves produced by extendedDiff were
`[M(0,2), M(1,3)]`

Applying them in order would mean:
`0123` + `M(0,2)` → `1203`
`1203` + `M(1,3)` → `1032`
This (`1032`) is also what NSTableView showed after applying the extended diff, but not what we wanted to achieve in the first place

Applying it in reversed order means
`0123` + `M(1,3)` → `0231`
`0231` + `M(0,2)` → `2301` which is what we wanted

So reversing the moves fixes this problem for NSTableView.

UITableView seems to not have these problems, I think it sorts the moves by itself somehow.

Unfortunately the related test
`0123` -> `3120`, resulting in  `[M(3,0), M(0,3)]` (or reversed depending on this PR)
 is not animated by NSTableView at all. I think this is because it applies them in sequence and the two moves basically cancel each other out.
Is there something else we could use for NSTableView which would work sequentially?

Again, UITableView seems to not have these problems.





