### PR TITLE
Fix NSTableView animations

### DIFF
--- a/Sources/Differ/Diff+AppKit.swift
+++ b/Sources/Differ/Diff+AppKit.swift
@@ -58,8 +58,6 @@ extension NSTableView {
         insertionAnimation: NSTableView.AnimationOptions = [],
         rowIndexTransform: (Int) -> Int = { $0 }
     ){
-        guard !patches.isEmpty else { return }
-
         beginUpdates()
         for patch in patches {
             switch patch {

--- a/Sources/Differ/Diff+AppKit.swift
+++ b/Sources/Differ/Diff+AppKit.swift
@@ -110,7 +110,7 @@ extension NSTableView {
         _ diff: ExtendedDiff,
         deletionAnimation: NSTableView.AnimationOptions = [],
         insertionAnimation: NSTableView.AnimationOptions = [],
-        indexPathTransform: (IndexPath) -> IndexPath
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 }
     ) {
         let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -62,8 +62,6 @@ public extension UITableView {
         insertionAnimation: DiffRowAnimation = .automatic,
         indexPathTransform: (IndexPath) -> IndexPath = { $0 }
     ) {
-        guard !diff.isEmpty else { return }
-
         let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 
         beginUpdates()
@@ -236,8 +234,6 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath,
         sectionTransform: (Int) -> Int
     ) {
-        guard !diff.isEmpty else { return }
-
         let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
         beginUpdates()
         deleteRows(at: update.itemDeletions, with: rowDeletionAnimation)

--- a/Sources/Differ/Diff+UIKit.swift
+++ b/Sources/Differ/Diff+UIKit.swift
@@ -62,6 +62,8 @@ public extension UITableView {
         insertionAnimation: DiffRowAnimation = .automatic,
         indexPathTransform: (IndexPath) -> IndexPath = { $0 }
     ) {
+        guard !diff.isEmpty else { return }
+
         let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 
         beginUpdates()
@@ -234,6 +236,8 @@ public extension UITableView {
         indexPathTransform: (IndexPath) -> IndexPath,
         sectionTransform: (Int) -> Int
     ) {
+        guard !diff.isEmpty else { return }
+
         let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
         beginUpdates()
         deleteRows(at: update.itemDeletions, with: rowDeletionAnimation)


### PR DESCRIPTION
# NSTableView
- Now based on patches, because NSTableView needs moves to be executed in order
- Changed Interface to use rowIndices, because there are not IndexPaths involved in the row animations of it
- I deprecated the previous methods for compatibility

# UITableView
- ~~prevent beginUpdates/endUpdates for empty diff~~ removed after discussion

